### PR TITLE
fix bug on recognizing Shift+Key press/release

### DIFF
--- a/KeyboardHook.cs
+++ b/KeyboardHook.cs
@@ -70,10 +70,19 @@ namespace dotSwitcher
                         var keybdinput = (KEYBDINPUT)Marshal.PtrToStructure(lParam, typeof(KEYBDINPUT));
                         var keyData = (Keys)keybdinput.Vk;
 
-                        keyData |= LowLevelAdapter.KeyPressed(Keys.ControlKey) ? Keys.Control : 0;
-                        keyData |= LowLevelAdapter.KeyPressed(Keys.Menu) ? Keys.Alt : 0;
-                        keyData |= LowLevelAdapter.KeyPressed(Keys.ShiftKey) ? Keys.Shift : 0;
+                        bool modifiers = 
+                             (Keys)keybdinput.Vk == Keys.RControlKey
+                            || (Keys)keybdinput.Vk == Keys.LControlKey
+                            || (Keys)keybdinput.Vk == Keys.RShiftKey
+                            || (Keys)keybdinput.Vk == Keys.LShiftKey
+                            || (Keys)keybdinput.Vk == Keys.Alt;
 
+                        if (!modifiers)
+                        {
+                            keyData |= LowLevelAdapter.KeyPressed(Keys.ControlKey) ? Keys.Control : 0;
+                            keyData |= LowLevelAdapter.KeyPressed(Keys.Menu) ? Keys.Alt : 0;
+                            keyData |= LowLevelAdapter.KeyPressed(Keys.ShiftKey) ? Keys.Shift : 0;
+                        }
                         var winPressed = LowLevelAdapter.KeyPressed(Keys.LWin) || LowLevelAdapter.KeyPressed(Keys.RWin);
 
                         var args = new KeyboardEventArgs(keyData, winPressed, key_down);

--- a/SettingsForm.cs
+++ b/SettingsForm.cs
@@ -182,6 +182,7 @@ namespace dotSwitcher
         }
         void kbdHook_KeyboardEvent(object sender, KeyboardEventArgs e)
         {
+            if (!e.Pressed) return;
             if (currentHotkeyType != HotKeyType.None)
             {
                 var vk = e.KeyCode;

--- a/Switcher.cs
+++ b/Switcher.cs
@@ -120,13 +120,11 @@ namespace dotSwitcher
         {
             var vkCode = evtData.KeyCode;
 
+            readyToSwitch = false;
             if (evtData.Equals(settings.SwitchLayoutHotkey))
             {
                 readyToSwitch = true;
-                return;
             }
-
-            readyToSwitch = false;
 
             if (evtData.Equals(settings.SwitchHotkey))
             {


### PR DESCRIPTION
Вот еще кое-какие добавления, которые я не успел залить:
1. Правильно отображаются клавиши в редакторе настроек
2. Лучше определяется комбинации при отжимании клавиши. Работаю с клавишей переключения RShift, глюков  нет. 

Не сделано
1. Не до конца изучил вопрос при переключении по другим клавишам. Например комбинация Ctrl+Alt (если это не системная настройка), однозначно будут глюки при текущем способе хранения комбинаций. Например 
Press Ctrl ... Press Alt ... Release Ctrl ... Release Alt
Press Ctrl ... Press Alt ... Release Alt ... Release Ctrl
Сработают по разному.
